### PR TITLE
Update README - using mix setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,15 @@ mix deps.get
 
 3. Postgres must be running
 
-4. Run migration
+4. Setup Database
 
 ```
-mix ecto.migrate
-```
-5. Run seeds file.
-
-```
-mix run priv/repo/seeds.exs
+mix ecto.setup
 ```
 
-6. Use `.env-sample` file to create your environment variables, set your username/password to your SMTP server, if don't have one just create with any name. In Dev environment you can access sent emails using Bamboo viewer (localhost:4000/sent_emails).
+5. Use `.env-sample` file to create your environment variables, set your username/password to your SMTP server, if don't have one just create with any name. In Dev environment you can access sent emails using Bamboo viewer (localhost:4000/sent_emails).
 
-7. Run the project
+6. Run the project
 
 ```
 iex -S mix phx.server


### PR DESCRIPTION
Happy Hacktoberfest 🎉 

I think we needs `mix ecto.create` when local setup.
So I suggest using `mix ecto.setup` instead of `mix ecto.create`, `mix ecto.migrate` and `mix run priv/repo/seeds`